### PR TITLE
Creating hooks

### DIFF
--- a/post-checkout
+++ b/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git submodule update --remote .githooks

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+declare -a patterns=(
+    "\b[A-Z0-9]{20}\b"
+    "\b[A-Za-z0-9\/+=]{40}\b"
+    "\b[0-9]{12}\b"
+    "\b[a-z0-9]{32}\b"
+    "\b[A-Z]{2}[0-9]{6}[A-Z]{1}\b"
+    "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    "PRIVATE KEY-----"
+    "\b[A-Za-z0-9._%+-]{1,}@[A-Za-z0-9]{1,}.[A-Za-z0-9]{1,4}.[A-Za-z0-9]{1,4}\b"
+    "\b.[a-z]{2}-[a-z]{4,9}-[0-9]{1}.\b"
+)
+
+declare -a descriptions=(
+    "AWS access key ID"
+    "40 character random (e.g. AWS secret access key, PAT)"
+    "AWS account number"
+    "16 byte hex (e.g. S3 bucket name)"
+    "NINO"
+    "IP address"
+    "Private key (e.g. rsa private key, openssh private key)"
+    "Email addresses"
+    "Regions embedded as part of resource descriptions"
+)
+
+if [ -d ".gitsecret" ]; then
+    git secret hide
+fi
+
+match=0
+for i in "${!patterns[@]}"
+do
+    git diff-index -p -M --cached HEAD -- | grep -v "Subproject commit" |
+    grep '^+[^+]' | grep -Eq "${patterns[$i]}" &&
+    echo "Blocking commit: ${descriptions[$i]} detected in patch" &&
+    ((match++))
+done
+
+if (( match > 0 )); then
+    echo "If the above are false positives then you can use the --no-verify flag to skip checks"
+    echo "git commit --no-verify"
+    exit 1
+fi
+
+if [ -f "initial-commit.sh" ]; then
+    echo "The inital-commit script has been found in your repo root. Please run: "
+    echo "make initial-commit"
+    exit 1
+fi


### PR DESCRIPTION
post-checkout : This is designed to update the `.githooks` submodule, whever there is a checkout action.  If this is deemed too aggressive, we can look to adjust to something else.

pre-commit : This as been adjusted to ignore lines beginning `Subproject commit` to avoid triggering its own pre-commit check ("40 character random (e.g. AWS secret access key, PAT)").  It also checks for the initial-commit script existing in the repo root, and will block commits if it does.  This is to double check users are running `make initial-commit` after creating a new repo.