### PR TITLE
Better feedback and created omission targets for IPs and emails

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,14 +1,12 @@
 #!/bin/bash
-
+#set -x
 declare -a patterns=(
     "\b[A-Z0-9]{20}\b"
     "\b[A-Za-z0-9\/+=]{40}\b"
     "\b[0-9]{12}\b"
     "\b[a-z0-9]{32}\b"
     "\b[A-Z]{2}[0-9]{6}[A-Z]{1}\b"
-    "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
     "PRIVATE KEY-----"
-    "\b[A-Za-z0-9._%+-]{1,}@[A-Za-z0-9]{1,}.[A-Za-z0-9]{1,4}.[A-Za-z0-9]{1,4}\b"
     "\b.[a-z]{2}-[a-z]{4,9}-[0-9]{1}.\b"
 )
 
@@ -18,15 +16,45 @@ declare -a descriptions=(
     "AWS account number"
     "16 byte hex (e.g. S3 bucket name)"
     "NINO"
-    "IP address"
     "Private key (e.g. rsa private key, openssh private key)"
     "Email addresses"
     "Regions embedded as part of resource descriptions"
 )
 
+declare -a email_patterns=(
+    "\b[A-Za-z0-9._%+-]{1,}@[A-Za-z0-9]{1,}.[A-Za-z0-9]{1,4}.[A-Za-z0-9]{1,4}\b"
+)
+
+declare -a email_descriptions=(
+    "Email addresses"
+)
+
+declare -a email_omissions=(
+    "grep -v \"snyk/snyk@\"|"
+    "grep -v \"create-release@latest\"|"
+    "grep -v \"checkout@master\"|"
+    "grep -v \"Publish-Docker-Github-Action@master\"|"
+    "grep -v \"docker@master\"|"
+)
+
+declare -a ip_patterns=(
+    "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+)
+
+declare -a ip_descriptions=(
+    "IP address"
+)
+
+declare -a ip_omissions=(
+    "grep -v \"169.254.169.254\"|"
+    "grep -v \"0.0.0.0\"|"
+    "grep -v \"127.0.0.1\"|"
+)
+
 if [ -d ".gitsecret" ]; then
     git secret hide
 fi
+
 
 match=0
 for i in "${!patterns[@]}"
@@ -34,17 +62,42 @@ do
     git diff-index -p -M --cached HEAD -- | grep -v "Subproject commit" |
     grep '^+[^+]' | grep -Eq "${patterns[$i]}" &&
     echo "Blocking commit: ${descriptions[$i]} detected in patch" &&
+    echo "This part of your change triggered this issue:" &&
+    git diff-index -p -M --cached HEAD -- | grep -v "Subproject commit" |
+    grep '^+[^+]' | grep -E "${patterns[$i]}" &&
     ((match++))
 done
 
-if (( match > 0 )); then
+email_match=0
+for i in "${!email_patterns[@]}"
+do
+    git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
+    #git diff-index -p -M --cached HEAD -- | ${email_omissions[@]}
+    grep '^+[^+]' | grep -Eq "${email_patterns[$i]}" &&
+    echo "Blocking commit: ${email_descriptions[$i]} detected in patch" &&
+    echo "This part of your change triggered this issue:" &&
+    git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
+    #git diff-index -p -M --cached HEAD -- | ${email_omissions[@]}
+    grep '^+[^+]' | grep -E "${email_patterns[$i]}" &&
+    ((email_match++))
+done
+
+ip_match=0
+for i in "${!ip_patterns[@]}"
+do
+    git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
+    #git diff-index -p -M --cached HEAD -- | ${ip_omissions[@]}
+    grep '^+[^+]' | grep -Eq "${ip_patterns[$i]}" &&
+    echo "Blocking commit: ${ip_descriptions[$i]} detected in patch" &&
+    echo "This part of your change triggered this issue:" &&
+    git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
+    #git diff-index -p -M --cached HEAD -- | ${ip_omissions[@]}
+    grep '^+[^+]' | grep -E "${ip_patterns[$i]}" &&
+    ((ip_match++))
+done
+
+if (( match > 0 | email_match > 0 | ip_match > 0)); then
     echo "If the above are false positives then you can use the --no-verify flag to skip checks"
     echo "git commit --no-verify"
-    exit 1
-fi
-
-if [ -f "initial-commit.sh" ]; then
-    echo "The inital-commit script has been found in your repo root. Please run: "
-    echo "make initial-commit"
     exit 1
 fi

--- a/pre-commit
+++ b/pre-commit
@@ -53,7 +53,6 @@ do
     ((match++))
 done
 
-email_match=0
 for i in "${!email_patterns[@]}"
 do
     git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
@@ -62,10 +61,9 @@ do
     echo "This part of your change triggered this issue:" &&
     git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
     grep '^+[^+]' | grep -E "${email_patterns[$i]}" &&
-    ((email_match++))
+    ((match++))
 done
 
-ip_match=0
 for i in "${!ip_patterns[@]}"
 do
     git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
@@ -74,10 +72,10 @@ do
     echo "This part of your change triggered this issue:" &&
     git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
     grep '^+[^+]' | grep -E "${ip_patterns[$i]}" &&
-    ((ip_match++))
+    ((match++))
 done
 
-if (( match > 0 | email_match > 0 | ip_match > 0)); then
+if (( match > 0 )); then
     echo "If the above are false positives then you can use the --no-verify flag to skip checks"
     echo "git commit --no-verify"
     exit 1

--- a/pre-commit
+++ b/pre-commit
@@ -17,7 +17,6 @@ declare -a descriptions=(
     "16 byte hex (e.g. S3 bucket name)"
     "NINO"
     "Private key (e.g. rsa private key, openssh private key)"
-    "Email addresses"
     "Regions embedded as part of resource descriptions"
 )
 
@@ -29,26 +28,12 @@ declare -a email_descriptions=(
     "Email addresses"
 )
 
-declare -a email_omissions=(
-    "grep -v \"snyk/snyk@\"|"
-    "grep -v \"create-release@latest\"|"
-    "grep -v \"checkout@master\"|"
-    "grep -v \"Publish-Docker-Github-Action@master\"|"
-    "grep -v \"docker@master\"|"
-)
-
 declare -a ip_patterns=(
     "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
 )
 
 declare -a ip_descriptions=(
     "IP address"
-)
-
-declare -a ip_omissions=(
-    "grep -v \"169.254.169.254\"|"
-    "grep -v \"0.0.0.0\"|"
-    "grep -v \"127.0.0.1\"|"
 )
 
 if [ -d ".gitsecret" ]; then
@@ -72,12 +57,10 @@ email_match=0
 for i in "${!email_patterns[@]}"
 do
     git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
-    #git diff-index -p -M --cached HEAD -- | ${email_omissions[@]}
     grep '^+[^+]' | grep -Eq "${email_patterns[$i]}" &&
     echo "Blocking commit: ${email_descriptions[$i]} detected in patch" &&
     echo "This part of your change triggered this issue:" &&
     git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
-    #git diff-index -p -M --cached HEAD -- | ${email_omissions[@]}
     grep '^+[^+]' | grep -E "${email_patterns[$i]}" &&
     ((email_match++))
 done
@@ -86,12 +69,10 @@ ip_match=0
 for i in "${!ip_patterns[@]}"
 do
     git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
-    #git diff-index -p -M --cached HEAD -- | ${ip_omissions[@]}
     grep '^+[^+]' | grep -Eq "${ip_patterns[$i]}" &&
     echo "Blocking commit: ${ip_descriptions[$i]} detected in patch" &&
     echo "This part of your change triggered this issue:" &&
     git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
-    #git diff-index -p -M --cached HEAD -- | ${ip_omissions[@]}
     grep '^+[^+]' | grep -E "${ip_patterns[$i]}" &&
     ((ip_match++))
 done


### PR DESCRIPTION
This will now skip certain IP's and email looking lines, and will provide feedback on what lines have actually been caught...

If we have a file containing:
```
me@college.com
127.0.0.1
169.254.169.254
snyk/snyk@0.0.8
0.0.0.0
192.168.0.1
ABCDEABABC12ABC1ABCD
Subproject commit c3f01dc8862123d317dd46284b05b6892c7b29bc
```
The pre-comit hook will return:
```
Blocking commit: AWS access key ID detected in patch
This part of your change triggered this issue:
+ABCDEABABC12ABC1ABCD
Blocking commit: Email addresses detected in patch
This part of your change triggered this issue:
+me@college.com
Blocking commit: IP address detected in patch
This part of your change triggered this issue:
+192.168.0.1
If the above are false positives then you can use the --no-verify flag to skip checks
git commit --no-verify
```  
Unfortunately done without the array as it was inserting unwanted single quotes in the for loop, breaking the commands.  I am open to improvements.
